### PR TITLE
Add BUN_BE_BUN feature flag and fix standalone module graph loading

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1815,29 +1815,31 @@ pub const Command = struct {
         }
 
         // bun build --compile entry point
-        if (try bun.StandaloneModuleGraph.fromExecutable(bun.default_allocator)) |graph| {
-            context_data = .{
-                .args = std.mem.zeroes(Api.TransformOptions),
-                .log = log,
-                .start_time = start_time,
-                .allocator = bun.default_allocator,
-            };
-            global_cli_ctx = &context_data;
-            var ctx = global_cli_ctx;
+        if (!bun.getRuntimeFeatureFlag(.BUN_BE_BUN)) {
+            if (try bun.StandaloneModuleGraph.fromExecutable(bun.default_allocator)) |graph| {
+                context_data = .{
+                    .args = std.mem.zeroes(Api.TransformOptions),
+                    .log = log,
+                    .start_time = start_time,
+                    .allocator = bun.default_allocator,
+                };
+                global_cli_ctx = &context_data;
+                var ctx = global_cli_ctx;
 
-            ctx.args.target = Api.Target.bun;
-            if (bun.argv.len > 1) {
-                ctx.passthrough = bun.argv[1..];
-            } else {
-                ctx.passthrough = &[_]string{};
+                ctx.args.target = Api.Target.bun;
+                if (bun.argv.len > 1) {
+                    ctx.passthrough = bun.argv[1..];
+                } else {
+                    ctx.passthrough = &[_]string{};
+                }
+
+                try @import("./bun_js.zig").Run.bootStandalone(
+                    ctx,
+                    graph.entryPoint().name,
+                    graph,
+                );
+                return;
             }
-
-            try @import("./bun_js.zig").Run.bootStandalone(
-                ctx,
-                graph.entryPoint().name,
-                graph,
-            );
-            return;
         }
 
         debug("argv: [{s}]", .{bun.fmt.fmtSlice(bun.argv, ", ")});

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -5,6 +5,7 @@ const bun = @import("bun");
 /// The field names correspond exactly to the expected environment variable names.
 pub const RuntimeFeatureFlag = enum {
     BUN_ASSUME_PERFECT_INCREMENTAL,
+    BUN_BE_BUN,
     BUN_DEBUG_NO_DUMP,
     BUN_DESTRUCT_VM_ON_EXIT,
     BUN_DISABLE_SLOW_LIFECYCLE_SCRIPT_LOGGING,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1708,12 +1708,12 @@ function internalConnect(self, options, address, port, addressType, localAddress
 
   if (localAddress || localPort) {
     if (addressType === 4) {
-      localAddress ||= '0.0.0.0';
+      localAddress ||= "0.0.0.0";
       // TODO:
       // err = self._handle.bind(localAddress, localPort);
     } else {
       // addressType === 6
-      localAddress ||= '::';
+      localAddress ||= "::";
       // TODO:
       // err = self._handle.bind6(localAddress, localPort, flags);
     }


### PR DESCRIPTION
## Summary
- Add new `BUN_BE_BUN` runtime feature flag to the `RuntimeFeatureFlag` enum
- Skip standalone module graph loading when `BUN_BE_BUN` feature flag is enabled

## Test plan
- [x] Build compiles successfully with new feature flag
- [x] Existing functionality remains unchanged when flag is not set
- [x] Standalone module graph loading is properly guarded by feature flag

🤖 Generated with [OpenCode](https://opencode.ai)